### PR TITLE
Moved coords and address to popup on marker. Wrap old in noscript

### DIFF
--- a/bornhack/templates/info.html
+++ b/bornhack/templates/info.html
@@ -31,10 +31,12 @@ Info | {{ block.super }}
         Where is BornHack going to take place?
       </h2>
       <div id="map" class="map"></div>
-      <p>
-      <strong>Coordinates</strong>: 55.011520, 14.975360<br />
-      <strong>Address</strong>: Baunevej 11, 3720 Aakirkeby
-      </p>
+      <noscript>
+        <p>
+         <strong>Coordinates</strong>: 55.011520, 14.975360<br />
+         <strong>Address</strong>: Baunevej 11, 3720 Aakirkeby
+        </p>
+      </noscript>
     </div>
   </div>
 
@@ -257,5 +259,9 @@ Info | {{ block.super }}
 
     var camp_latlong = [55.011520, 14.975360];
     L.marker(camp_latlong).addTo(map);
+
+    L.marker(camp_latlong).addTo(map)
+      .bindPopup('<strong>Coordinates:</strong><br>55.011520, 14.975360<br><strong>Address:</strong><br>Baunevej 11, 3720 Aakirkeby')
+      .openPopup();
   </script>
 {% endblock %}


### PR DESCRIPTION
Shows the coordinates and address information as a popup from the mark in the map. noscript around the existing.

<img width="702" alt="5jg7v1pnc2" src="https://cloud.githubusercontent.com/assets/741217/17407604/2897fdf6-5a68-11e6-816c-e252d9138f8e.png">

