### PR TITLE
Add href attribute to Schedule -> All Days event link

### DIFF
--- a/src/program/static/js/event_instance_websocket.js
+++ b/src/program/static/js/event_instance_websocket.js
@@ -247,6 +247,7 @@ function render_event_instance(event_instance) {
         'background-color: ' + event_instance['bg-color'] +
         '; color: ' + event_instance['fg-color']);
     element.classList.add('event');
+    element.setAttribute('href', event_instance['url']);
     element.dataset.eventInstanceId = event_instance['id'];
 
     time_element = document.createElement('small');


### PR DESCRIPTION
This allows middle clicking to open in a new tab and other expected native link behavior on events on the `Schedule -> All Days` screen.

This allows people like me to do my page parking when trying to get an overview of interesting events

Also it's according to spec