### PR TITLE
Update psycopg2 to latest version

### DIFF
--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -26,7 +26,7 @@ ipython==5.3.0
 irc3==0.9.8
 oauthlib==2.0.1
 olefile==0.44
-psycopg2==2.6.2
+psycopg2==2.7.5
 python3-openid==3.0.10
 pytz==2016.10
 qrcode==5.3


### PR DESCRIPTION
The old version `2.6.2` is causing issues like this:

```
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.4'
```

Recommend to test this by just deploying it into production, and if it works, then that's probably fine.