### PR TITLE
Use psycopg2-binary

### DIFF
--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -26,7 +26,7 @@ ipython==5.3.0
 irc3==0.9.8
 oauthlib==2.0.1
 olefile==0.44
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 python3-openid==3.0.10
 pytz==2016.10
 qrcode==5.3


### PR DESCRIPTION
Avoids this warning:

```
.virtualenvs/bornhack/lib/python3.6/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```