### PR TITLE
Make target and Dockerfile for elm stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Otherwise start uwsgi or similar to serve the application.
 
 Enjoy!
 
+### Elm schedule
+
+To build the schedule source with Elm, you need NPM and Elm, but if you have Docker, you can also run the `docker` make target:
+
+```
+cd schedule
+make docker
+```
+
 ## Notes
 
 ### Add a camp

--- a/schedule/Dockerfile
+++ b/schedule/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:bionic
+
+# install latest python and nodejs
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      curl \
+      software-properties-common \
+      gcc g++ make
+
+# Install nodejs and add 'hold' such that it doesn't get upgraded
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm
+
+RUN npm install -g elm
+
+VOLUME /bornhack/  # for mounting the whl files into other docker containers
+
+CMD cd /bornhack/schedule && \
+    make all

--- a/schedule/Makefile
+++ b/schedule/Makefile
@@ -3,3 +3,16 @@ all:
 
 debug:
 	elm-make src/Main.elm --debug --warn --output ../src/program/static/js/elm_based_schedule.js
+
+docker:
+	docker image build \
+			-f Dockerfile \
+			-t "bornhack-elm" .
+	cd .. && docker run --init \
+			-v $$PWD:/bornhack \
+			"bornhack-elm" \
+
+clean:
+	docker container prune -f
+	docker image prune -f
+


### PR DESCRIPTION
Somewhat protects developers by not requiring them to run NPM stuff directly in their development envs.