### PR TITLE
Add kitchen sink camp program JSON endpoint

### DIFF
--- a/src/program/urls.py
+++ b/src/program/urls.py
@@ -15,6 +15,9 @@ urlpatterns = [
         name='noscript_schedule_index'
     ),
     path(
+        'json/', JSONView.as_view(), name="json_view"
+    ),
+    path(
         'ics/', ICSView.as_view(), name="ics_view"
     ),
     path(

--- a/src/program/views.py
+++ b/src/program/views.py
@@ -1,6 +1,7 @@
 import logging
 from collections import OrderedDict
 
+import json
 from django.views.generic import ListView, TemplateView, DetailView, View
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.conf import settings
@@ -34,7 +35,90 @@ from . import models
 from .forms import SpeakerProposalForm, EventProposalForm
 
 
+from camps.models import Camp
+from .models import (
+    Event,
+    EventInstance,
+    Favorite,
+    EventLocation,
+    EventType,
+    EventTrack,
+    Speaker
+)
+
+
 logger = logging.getLogger("bornhack.%s" % __name__)
+
+
+###################################################################################################
+# json program
+
+
+class JSONView(CampViewMixin, View):
+    def get(self, request, *args, **kwargs):
+        user = self.request.user
+        data = {}
+
+        camp = self.camp
+        days = list(map(
+            lambda day:
+                {
+                    'repr': day.lower.strftime('%A %Y-%m-%d'),
+                    'iso': day.lower.strftime('%Y-%m-%d'),
+                    'day_name': day.lower.strftime('%A'),
+                },
+            camp.get_days('camp')
+        ))
+
+        events_query_set = Event.objects.filter(track__camp=camp)
+        events = list([x.serialize() for x in events_query_set])
+
+        event_instances_query_set = EventInstance.objects.filter(
+            event__track__camp=camp
+        )
+        event_instances = list([
+            x.serialize(user=user)
+            for x in event_instances_query_set
+        ])
+
+        event_locations_query_set = EventLocation.objects.filter(
+            camp=camp
+        )
+        event_locations = list([
+            x.serialize()
+            for x in event_locations_query_set
+        ])
+
+        event_types_query_set = EventType.objects.filter()
+        event_types = list([
+            x.serialize()
+            for x in event_types_query_set
+        ])
+
+        event_tracks_query_set = EventTrack.objects.filter(
+            camp=camp
+        )
+        event_tracks = list([
+            x.serialize()
+            for x in event_tracks_query_set
+        ])
+
+        speakers_query_set = Speaker.objects.filter(camp=camp)
+        speakers = list([x.serialize() for x in speakers_query_set])
+
+        data = {
+            "events": events,
+            "event_instances": event_instances,
+            "event_locations": event_locations,
+            "event_types": event_types,
+            "event_tracks": event_tracks,
+            "speakers": speakers,
+            "days": days,
+        }
+
+        response = HttpResponse(json.dumps(data))
+        response['Content-Type'] = 'application/json'
+        return response
 
 
 ###################################################################################################


### PR DESCRIPTION
This lets people who wanna have at the schedule data GET it at `/:camp-slug/program/json/`, but it's mostly intended to supply metrics team with some events for a timeline.

Maybe there should be per-type sub-endpoints? ie. `/:camp-slug/program/json/speakers` - the kitchen sink might be a bit slow/too much for some applications.

Or maybe it should be done with full-on Django REST Framework, but ehhhhhh that's a lot of effort

