### PR TITLE
qrcode: move caption before qrcode

### DIFF
--- a/src/utils/templatetags/qrcode.py
+++ b/src/utils/templatetags/qrcode.py
@@ -17,7 +17,7 @@ def qr_code(value):
 
     return mark_safe(
         "<figure style='text-align: center;'>"
-        '<img src="data:image/png;base64,{}" alt="">'
         "<figcaption style='text-align: center;'>{}</figcaption>"
+        '<img src="data:image/png;base64,{}" alt="">'
         "</figure>".format(data.decode(), value)
     )


### PR DESCRIPTION
This allows reading the qr code description on small screens (like from
the laptop at the infodesk) without scrolling down all the time ;-)