### PR TITLE
Team shifts: display public credit name as well

### DIFF
--- a/src/teams/templates/team_shift_list.html
+++ b/src/teams/templates/team_shift_list.html
@@ -47,7 +47,7 @@
                 {{ shift.people_required }}
             <td>
                 {% for member in shift.team_members.all %}
-                {{ member.user }}{% if not forloop.last %},{% endif %}
+		{{ member.user.profile.get_public_credit_name }}{% if not forloop.last %},{% endif %}
                 {% empty %}
                     None!
                 {% endfor %}


### PR DESCRIPTION
The public credit name is usually more recognizable.

I have not tested this at all, please review.