### PR TITLE
Fixed top menu that wrapped around on narrow view

### DIFF
--- a/src/static_src/css/bornhack.css
+++ b/src/static_src/css/bornhack.css
@@ -62,8 +62,8 @@ a, a:active, a:focus {
   margin-top: 6px;
 }
 
-#top-navbar > .nav li a {
-   padding: 30px 7px;
+#top-navbar > .nav > li > a {
+  padding: 30px 7px;
 }
 
 .nav .dropdown-menu  {
@@ -98,7 +98,11 @@ a, a:active, a:focus {
     border-top: 1px solid #ccc;
   }
   .navbar .nav li a {
-    padding: 15px;
+    padding: 20px !important;
+  }
+
+  .btn-group-vertical > .btn{
+    padding: 20px;
   }
 }
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -78,16 +78,30 @@
             <li><a href="{% url 'wish_list_redirect' %}">Wishlist</a></li>
 
             {% if request.user.is_staff %}
-            <li><a href="{% url 'admin:index' %}">Django Admin</a></li>
+            <li><a href="{% url 'admin:index' %}">Admin</a></li>
             {% endif %}
           </ul>
           <ul class="nav navbar-nav navbar-right">
             {% if user.is_authenticated %}
-            <li><a href="{% url 'profiles:detail' %}">Account</a></li>
-            <li>
-              <a href="{% url 'account_logout' %}">
-                Logout
-              </a>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Account<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <li><a href="{% url 'profiles:detail' %}">Profile</a></li>
+                {% if user.orders.exists %}
+                {% url 'shop:order_list' as orders_list_url %}
+                <li><a href="{{ orders_list_url }}">Orders</a></li>
+          
+                {% url 'tickets:shopticket_list' as ticket_list_url %}
+                <li><a href="{{ ticket_list_url }}">Tickets</a></li>
+          
+                {% if user.creditnotes.exists %}
+                {% url 'shop:creditnote_list' as creditnote_list_url %}
+                <li><a href="{{ creditnote_list_url }}">Credit Notes</a></li>
+                {% endif %}
+                {% endif %}
+                <li role="separator" class="divider"></li>
+                <li><a href="{% url 'account_logout' %}">Logout</a></li>
+              </ul>
             </li>
             {% else %}
             <li><a href="{% url 'account_login' %}">Login</a></li>


### PR DESCRIPTION
Fixes issue #475

Also shows link to Orders, Tickets and Creditnotes if relevant in the account menu

In addition to the wrapping, the margin of the dropdown menus have also been adjusted a tad