### PR TITLE
Switch Vidir to Graffen on CoC page

### DIFF
--- a/src/templates/coc.html
+++ b/src/templates/coc.html
@@ -32,7 +32,7 @@ Code of Conduct | {{ block.super }}
 <p>
 <ul>
   <li>Find a member of event staff and let them know. All our volunteer staff will be briefed on how to handle a harassment situation.</li>
-  <li>Drop us an email at conduct@bornhack.org. If you prefer to speak to a female you can write to sarah@bornhack.org. If you prefer to speak to a male you can write to vidir@bornhack.org.</li>
+  <li>Drop us an email at conduct@bornhack.org. If you prefer to speak to a female you can write to sarah@bornhack.org. If you prefer to speak to a male you can write to graffen@bornhack.org.</li>
   <li>Call the on duty CERT person on +4531550497 (24 hours)</li>
 </ul>
 </p>


### PR DESCRIPTION
Update the CoC page to mention graffen instead of Vidir. 