### PR TITLE
team shifts: implement marking shifts for sale

### DIFF
--- a/src/teams/models.py
+++ b/src/teams/models.py
@@ -401,7 +401,7 @@ class TeamShift(CampRelatedModel):
 
     shift_range = DateTimeRangeField()
 
-    team_members = models.ManyToManyField(TeamMember, blank=True)
+    team_members = models.ManyToManyField(TeamMember, blank=True, through=TeamShiftAssignment)
 
     people_required = models.IntegerField(default=1)
 
@@ -420,3 +420,21 @@ class TeamShift(CampRelatedModel):
     @property
     def users(self):
         return [member.user for member in self.team_members.all()]
+
+class TeamShiftAssignment(CampRelatedModel):
+    team_shift = models.ForeignKey(
+        "teams.TeamShift",
+        on_delete=models.CASCADE,
+        help_text="The shift",
+    )
+
+    team_member = models.ForeignKey(
+        "teams.TeamMember",
+        on_delete=models.CASCADE,
+        help_text="The team member on shift",
+    )
+
+    for_sale = models.BooleanField(
+        default=False,
+        help_text="Is the shift assignment for sale?",
+    )

--- a/src/teams/templates/team_shift_list.html
+++ b/src/teams/templates/team_shift_list.html
@@ -50,7 +50,7 @@ Shifts | {{ block.super }}
                 {{ shift.people_required }}
             <td>
                 {% for member in shift.team_members.all %}
-		{{ member.user.profile.get_public_credit_name }}{% if not forloop.last %},{% endif %}
+		{{ member.user.profile.get_public_credit_name }}{% if member.for_sale %} <em>(for sale!)</em>{% endif %}{% if not forloop.last %},{% endif %}
                 {% empty %}
                     None!
                 {% endfor %}
@@ -71,7 +71,11 @@ Shifts | {{ block.super }}
                    href="{% url 'teams:shift_member_drop' camp_slug=camp.slug team_slug=team.slug pk=shift.pk %}">
                     <i class="fas fa-thumbs-down"></i> Unassign me
                 </a>
-                {% elif shift.people_required > shift.team_members.count %}
+                <a class="btn btn-warning"
+                   href="{% url 'teams:shift_member_sell' camp_slug=camp.slug team_slug=team.slug pk=shift.pk %}">
+                    <i class="fas fa-thumbs-down"></i> Sell shift
+                </a>
+                {% elif shift.people_required > shift.team_members.filter(for_sale=False).count %}
                 <a class="btn btn-success"
                    href="{% url 'teams:shift_member_take' camp_slug=camp.slug team_slug=team.slug pk=shift.pk %}">
                     <i class="fas fa-thumbs-up"></i> Assign me

--- a/src/teams/templates/team_user_shifts.html
+++ b/src/teams/templates/team_user_shifts.html
@@ -34,6 +34,10 @@ Your shifts | {{ block.super }}
         <td>
             {{ shift.shift_range.upper|date:'H:i' }}
         </td>
+	<td>
+          <a class="btn btn-warning"
+             href="{% url 'teams:shift_member_sell' camp_slug=camp.slug team_slug=shift.team.slug pk=shift.pk %}">
+              <i class="fas fa-thumbs-down"></i> Sell shift
         <td>
           <a class="btn btn-danger"
              href="{% url 'teams:shift_member_drop' camp_slug=camp.slug team_slug=shift.team.slug pk=shift.pk %}">

--- a/src/teams/urls.py
+++ b/src/teams/urls.py
@@ -179,6 +179,11 @@ urlpatterns = [
                                             MemberDropsShift.as_view(),
                                             name="shift_member_drop",
                                         ),
+                                        path(
+                                            "sell",
+                                            MemberSellsShift.as_view(),
+                                            name="shift_member_sell",
+                                        ),
                                     ]
                                 ),
                             ),


### PR DESCRIPTION
A common occurence is that not enough people volunteer for shifts at
first, and then the few volunteers take all the shifts (too many). Then
late comers aren't able to take any shifts.

This commit implements a third state for shift assignment: for sale. A
shift marked for sale means the team member is able to take the shift if
need be, but would rather someone else takes the shift. Another team
member will be able to take shifts at the same time even if the required
number of people are met.

The current semantics is for-sale shifts are replaced eagerly. Another
possible implementation would be to only replace for-sale shifts if the
number of required people is met.

I have not tested this #yolo