### PR TITLE
Email address in backoffice

### DIFF
--- a/src/backoffice/templates/facility_detail_backoffice.html
+++ b/src/backoffice/templates/facility_detail_backoffice.html
@@ -84,7 +84,7 @@
                 <table class="table">
                   <thead>
                     <tr>
-                      <th>Username</th>
+                      <th>Email</th>
                       <th>Created</th>
                       <th>Facility</th>
                       <th>Quick Feedback</th>
@@ -96,7 +96,7 @@
                   <tbody>
                     {% for feedback in facility.feedbacks.all %}
                       <tr>
-                        <td>{{ feedback.user|default:"N/A" }}</td>
+                        <td>{{ feedback.user.email|default:"N/A" }}</td>
                         <td>{{ feedback.created }}</td>
                         <td>{{ feedback.facility }}</td>
                         <td><i class="{{ feedback.quick_feedback.icon }} fa-2x"></i> {{ feedback.quick_feedback }}</td>

--- a/src/backoffice/templates/includes/order_list_panel.html
+++ b/src/backoffice/templates/includes/order_list_panel.html
@@ -3,7 +3,7 @@
   <thead>
     <tr>
       <th>Order #</th>
-      <th>User</th>
+      <th>Email</th>
       <th>Created</th>
       <th>Updated</th>
       <th>Products</th>
@@ -19,7 +19,7 @@
     {% for order in order_list %}
       <tr>
         <td>{{ order.id }}</td>
-        <td>{{ order.user.username }} &lt;{{ order.user.email }}&gt;</td>
+        <td>{{ order.user.email }}</td>
         <td data-order="{{ order.created|sortable }}">{{ order.created }}</td>
         <td data-order="{{ order.updated|sortable }}">{{ order.updated }}</td>
         <td><ul>{% for opr in order.oprs.all %}<li>{{ opr.product.name }} ({{ opr.quantity }}){% endfor %}</ul></td>

--- a/src/backoffice/templates/includes/speaker_list_table_backoffice.html
+++ b/src/backoffice/templates/includes/speaker_list_table_backoffice.html
@@ -1,8 +1,6 @@
 <table class="table table-striped{% if not nodatatable %} datatable{% endif %}">
   <thead>
     <tr>
-      <th>Name</th>
-      <th>Email</th>
       <th>Submitter</th>
       <th>Proposal</th>
       <th class="text-center">Event Conflicts</th>
@@ -13,9 +11,7 @@
   <tbody>
     {% for speaker in speaker_list %}
       <tr>
-        <td><i class="fas fa-user"></i> <a href="{% url 'backoffice:speaker_detail' camp_slug=camp.slug slug=speaker.slug %}">{{ speaker.name }}</a></td>
-        <td>{{ speaker.email }}</td>
-        <td><i class="fas fa-user"></i> {{ speaker.proposal.user }}</td>
+        <td><i class="fas fa-user"></i> <a href="{% url 'backoffice:speaker_detail' camp_slug=camp.slug slug=speaker.slug %}">{{ speaker.name }}</a> &lt;{{ speaker.email }}&gt;</td>
         <td><a href="{% url 'backoffice:speaker_proposal_detail' camp_slug=camp.slug pk=speaker.proposal.pk %}" class="btn btn-default"><i class="fas fa-search"></i> Show</a></td>
         <td class="text-center"><span class="badge">{{ speaker.event_conflicts.count }}</span></td>
         <td>

--- a/src/backoffice/templates/orders_merchandise.html
+++ b/src/backoffice/templates/orders_merchandise.html
@@ -22,7 +22,6 @@
       <thead>
         <tr>
           <th>Order</th>
-          <th>User</th>
           <th>Email</th>
           <th>OPR Id</th>
           <th>Product</th>
@@ -35,7 +34,6 @@
         {% for productrel in orderproductrelation_list %}
           <tr>
             <td><a href="/admin/shop/order/{{ productrel.order.id }}/change/">Order #{{ productrel.order.id }}</a></td>
-            <td>{{ productrel.order.user }}</td>
             <td>{{ productrel.order.user.email }}</td>
             <td>{{ productrel.id }}</td>
             <td>{{ productrel.product.name }}</td>

--- a/src/backoffice/templates/orders_village.html
+++ b/src/backoffice/templates/orders_village.html
@@ -22,7 +22,6 @@
       <thead>
         <tr>
           <th>Order</th>
-          <th>User</th>
           <th>Email</th>
           <th>OPR Id</th>
           <th>Product</th>
@@ -33,7 +32,6 @@
         {% for productrel in orderproductrelation_list %}
           <tr>
             <td><a href="/admin/shop/order/{{ productrel.order.id }}/change/">Order #{{ productrel.order.id }}</a></td>
-            <td>{{ productrel.order.user }}</td>
             <td>{{ productrel.order.user.email }}</td>
             <td>{{ productrel.id }}</td>
             <td>{{ productrel.product.name }}</td>

--- a/src/backoffice/templates/token_detail.html
+++ b/src/backoffice/templates/token_detail.html
@@ -39,14 +39,13 @@
       <table class="table table-striped{% if not nodatatable %} datatable{% endif %}">
         <thead>
           <tr>
-            <th>Username</th>
+            <th>Email</th>
             <th>Timestamp</th>
           </tr>
         </thead>
         <tbody>
           {% for tf in token.tokenfind_set.all %}
             <tr>
-              <td>{{ tf.user.username }}</td>
               <td>{{ tf.user.email }}</td>
               <td>{{ tf.created }}</td>
             </tr>

--- a/src/backoffice/templates/token_stats.html
+++ b/src/backoffice/templates/token_stats.html
@@ -15,7 +15,6 @@
         <table class="table table-striped{% if not nodatatable %} datatable{% endif %}">
           <thead>
             <tr>
-              <th>Username</th>
               <th>Email</th>
               <th>Finds</th>
             </tr>
@@ -23,7 +22,6 @@
           <tbody>
             {% for user in user_list %}
               <tr>
-                <td>{{ user.username }}</td>
                 <td>{{ user.email }}</td>
                 <td>{{ user.token_find_count }}</td>
               </tr>

--- a/src/economy/templates/includes/expense_list_panel.html
+++ b/src/economy/templates/includes/expense_list_panel.html
@@ -29,9 +29,9 @@
             <td><a href="{% url 'economy:expense_detail' camp_slug=camp.slug pk=expense.pk %}">{{ expense.pk }}</a></td>
           {% endif %}
           <td data-order="{{ expense.invoice_date|sortable }}">{{ expense.invoice_date }}</td>
-          <td>{{ expense.user }}</td>
+          <td>{{ expense.user.email }}</td>
           {% if not reimbursement %}
-            <td>{% if expense.paid_by_bornhack %}BornHack{% else %}{{ expense.user }}{% endif %}</td>
+            <td>{% if expense.paid_by_bornhack %}BornHack{% else %}{{ expense.user.email }}{% endif %}</td>
           {% endif %}
           <td>{{ expense.creditor.name }}</td>
           <td data-order="{{ expense.amount }}">{{ expense.amount }} DKK</td>

--- a/src/economy/templates/includes/reimbursement_list_panel.html
+++ b/src/economy/templates/includes/reimbursement_list_panel.html
@@ -24,8 +24,8 @@
           {% else %}
             <td>{{ reim.camp }}</td>
           {% endif %}
-          <td>{{ reim.user }}</td>
-          <td>{{ reim.reimbursement_user }}</td>
+          <td>{{ reim.user.email }}</td>
+          <td>{{ reim.reimbursement_user.email }}</td>
           <td>{{ reim.notes|default:"N/A" }}</td>
           <td data-order="{{ reim.amount }}">{{ reim.amount }} DKK</td>
           <td>{{ reim.paid|truefalseicon }}</td>

--- a/src/economy/templates/includes/revenue_list_panel.html
+++ b/src/economy/templates/includes/revenue_list_panel.html
@@ -19,7 +19,7 @@
         <tr>
           <td>{{ revenue.pk }}</td>
           <td data-order="{{ revenue.invoice_date|sortable }}">{{ revenue.invoice_date }}</td>
-          <td>{{ revenue.user }}</td>
+          <td>{{ revenue.user.email }}</td>
           <td>{{ revenue.debtor }}</td>
           <td data-order="{{ revenue.amount }}">{{ revenue.amount }} DKK</td>
           <td>{{ revenue.description }}</td>


### PR DESCRIPTION
In a lot of places in the backoffice, we show the "username". The username is the username part of the email address. Many of our participants uses [bornhack@theirowndomain.whatever](mailto:bornhack@theirowndomain.whatever) and thus have "bornhack1", "bornhack2", etc. as username. It would be nice to just display their email address instead.