### PR TITLE
Active token and timed token indicators

### DIFF
--- a/src/backoffice/templates/token_list.html
+++ b/src/backoffice/templates/token_list.html
@@ -19,6 +19,7 @@
             <thead>
               <tr>
                 <th>Token</th>
+                <th>Active</th>
                 <th>Category</th>
                 <th>Description</th>
                 <th>Finds</th>
@@ -29,6 +30,13 @@
               {% for token in token_list %}
                 <tr>
                   <td><a href="{% url 'backoffice:token_detail' camp_slug=camp.slug pk=token.pk %}">{{ token.token }}</a></td>
+                  <td>
+                      {% if token.active %}
+                      <i class="fas fa-check text-success"></i>
+                      {% else %}
+                      <i class="fas fa-ban text-danger"></i>
+                      {% endif %}
+                  </td>
                   <td>{{ token.category }}</td>
                   <td>{{ token.description }}</td>
                   <td>{{ token.tokenfind_set.count }}</td>

--- a/src/backoffice/templates/token_list.html
+++ b/src/backoffice/templates/token_list.html
@@ -36,6 +36,9 @@
                       {% else %}
                       <i class="fas fa-ban text-danger"></i>
                       {% endif %}
+                      {% if token.valid_when %}
+                      <i class="fas fa-clock"></i>
+                      {% endif %}
                   </td>
                   <td>{{ token.category }}</td>
                   <td>{{ token.description }}</td>

--- a/src/backoffice/templates/token_list.html
+++ b/src/backoffice/templates/token_list.html
@@ -37,7 +37,9 @@
                       <i class="fas fa-ban text-danger"></i>
                       {% endif %}
                       {% if token.valid_when %}
-                      <i class="fas fa-clock"></i>
+                      <span data-toggle="tooltip" data-placement="top" title="{{ token.valid_when }}">
+                          <i class="fas fa-clock text-success"></i>
+                      </span>
                       {% endif %}
                   </td>
                   <td>{{ token.category }}</td>


### PR DESCRIPTION
This PR is approved by @Hafpaf for fixing issue #1321

A tooltip showing the timestamp for timed token when hovering the clock icon has also been added.

![image](https://github.com/bornhack/bornhack-website/assets/17219001/19f271ef-e133-4d87-ac56-1266df3e0a8f)
