### PR TITLE
Fix 2FA removal form by actually showing the form.

### DIFF
--- a/src/profiles/templates/allauth_2fa/remove.html
+++ b/src/profiles/templates/allauth_2fa/remove.html
@@ -19,6 +19,7 @@
 
           <form method="post">
             {% csrf_token %}
+            {% bootstrap_form form %}
             <button class="btn btn-danger" type="submit">
               Yes, I'm sure
             </button>


### PR DESCRIPTION
Embarrassingly we had forgotten the actual input field for where a token should be inputted to disable 2FA. This introduces it again.

![image](https://github.com/bornhack/bornhack-website/assets/5782/c15c74a8-df47-4269-a078-f9ac3b132800)

Fixes #1203 