### PR TITLE
Format sortable friendly date/time in tables

### DIFF
--- a/src/phonebook/templates/dectregistration_list.html
+++ b/src/phonebook/templates/dectregistration_list.html
@@ -36,8 +36,8 @@
               <td>{{ entry.description|default:"N/A" }}</td>
               <td>{{ entry.publish_in_phonebook|yesno }}</td>
               <td>{{ entry.activation_code }}</td>
-              <td>{{ entry.created }}</td>
-              <td>{{ entry.updated }}</td>
+              <td>{{ entry.created|date:"Y-m-d H:i" }}</td>
+              <td>{{ entry.updated|date:"Y-m-d H:i" }}</td>
               <td>
                 <a href="{% url 'phonebook:dectregistration_update' camp_slug=camp.slug dect_number=entry.number %}" class="btn btn-primary"><i class="fas fa-edit"></i> Update</a>
                 <a href="{% url 'phonebook:dectregistration_delete' camp_slug=camp.slug dect_number=entry.number %}" class="btn btn-danger"><i class="fas fa-times"></i> Delete</a>

--- a/src/phonebook/templates/phonebook.html
+++ b/src/phonebook/templates/phonebook.html
@@ -36,7 +36,7 @@
             <td>{{ entry.number }}</td>
             <td>{{ entry.letters|default:"N/A" }}</td>
             <td>{{ entry.description|default:"N/A" }}</td>
-            <td>{{ entry.created }}</td>
+            <td>{{ entry.created|date:"Y-m-d H:i" }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/src/program/templates/event_detail.html
+++ b/src/program/templates/event_detail.html
@@ -65,7 +65,7 @@
       <h4>Schedule for <i>{{ event.title }}</i></h4>
       <ul class="list-group">
         {% for slot in event.event_slots.all %}
-          <li class="list-group-item">{{ slot.when.lower }} - {{ slot.when.upper }} at {{ slot.event_location.name }} <i class="fas fa-{{ slot.event_location.icon }}"></i></li>
+          <li class="list-group-item">{{ slot.when.lower|date:"Y-m-d H:i" }} - {{ slot.when.upper|date:"Y-m-d H:i" }} at {{ slot.event_location.name }} <i class="fas fa-{{ slot.event_location.icon }}"></i></li>
         {% empty %}
           Not scheduled yet
         {% endfor %}

--- a/src/program/templates/includes/event_list_table.html
+++ b/src/program/templates/includes/event_list_table.html
@@ -40,7 +40,7 @@
           <td class="text-center"><span class="hidden">{{ event.video_recording }}</span>{{ event.video_recording|truefalseicon }}</td>
           <td>
             {% for slot in event.event_slots.all %}
-              {{ slot.event_location.icon_html }} {{ slot.event_location.name }} at {{ slot.when.lower }}<br>
+              {{ slot.event_location.icon_html }} {{ slot.event_location.name }} at {{ slot.when.lower|date:"Y-m-d H:i" }}<br>
             {% empty %}
               <i>Not scheduled yet</i>
             {% endfor %}

--- a/src/rideshare/templates/rideshare/ride_list.html
+++ b/src/rideshare/templates/rideshare/ride_list.html
@@ -51,7 +51,7 @@
                                 <i class="fas fa-thumbs-up"></i> Needs ride
                               {% endif %}
                               <td>
-                                {{ ride.when|date:"c" }}
+                                {{ ride.when|date:"Y-m-d H:i" }}
                                 <td>
                                   {{ ride.from_location }}
                                   <td>


### PR DESCRIPTION
* in table columns of phonebook, rideshare & event list pages use variant of ISO 8601 extended format in minute precision but without "T" separator and timezone indicator resulting in columns that sort chronologically as expected but doesn't look too cryptic
* use the same format on event detail page to improve readability of event duration

This is a simple hardcoded remedy to #1392 & #1330. The proper solution would be using DataTable's `data-order` like suggested in #523 (and used in parts of backoffice and economy code) to determine ordering and let some sort of user preference determine appropriate formatting.