### PR TITLE
Fixing the phonebook api for json response

### DIFF
--- a/src/phonebook/urls.py
+++ b/src/phonebook/urls.py
@@ -2,7 +2,8 @@ from django.urls import include
 from django.urls import path
 from django.urls import re_path
 
-from .views import DectExportView
+from .views import DectExportCsvView
+from .views import DectExportJsonView
 from .views import DectRegistrationCreateView
 from .views import DectRegistrationDeleteView
 from .views import DectRegistrationListView
@@ -12,7 +13,8 @@ from .views import PhonebookListView
 app_name = "phonebook"
 urlpatterns = [
     path("", PhonebookListView.as_view(), name="list"),
-    path("csv/", DectExportView.as_view(), name="csv"),
+    path("csv/", DectExportCsvView.as_view(), name="csv"),
+    path("json/", DectExportJsonView.as_view(), name="json"),
     path(
         "dectregistrations/",
         include(

--- a/src/phonebook/urls.py
+++ b/src/phonebook/urls.py
@@ -2,7 +2,6 @@ from django.urls import include
 from django.urls import path
 from django.urls import re_path
 
-from .views import DectExportCsvView
 from .views import DectExportJsonView
 from .views import DectRegistrationCreateView
 from .views import DectRegistrationDeleteView
@@ -13,7 +12,6 @@ from .views import PhonebookListView
 app_name = "phonebook"
 urlpatterns = [
     path("", PhonebookListView.as_view(), name="list"),
-    path("csv/", DectExportCsvView.as_view(), name="csv"),
     path("json/", DectExportJsonView.as_view(), name="json"),
     path(
         "dectregistrations/",

--- a/src/phonebook/views.py
+++ b/src/phonebook/views.py
@@ -60,45 +60,6 @@ class DectExportJsonView(
         return phonebook
 
 
-class DectExportCsvView(
-    CampViewMixin, RaisePermissionRequiredMixin,
-    ScopedProtectedResourceView,
-):
-    """
-    CSV export for the POC team / DECT system
-    """
-
-    required_scopes = ["phonebook:read"]
-
-
-    def get(self, request, *args, **kwargs):
-        response = HttpResponse(content_type="text/csv")
-        response[
-            "Content-Disposition"
-        ] = f'attachment; filename="{self.camp.slug}-dect-export-{timezone.now()}.csv"'
-        writer = csv.writer(response)
-        writer.writerow(
-            [
-                "number",
-                "letters",
-                "description",
-                "activation_code",
-                "publish_in_phonebook",
-            ],
-        )
-        for dect in DectRegistration.objects.filter(camp=self.camp):
-            writer.writerow(
-                [
-                    dect.number,
-                    dect.letters,
-                    dect.description,
-                    dect.activation_code,
-                    dect.publish_in_phonebook,
-                ],
-            )
-        return response
-
-
 class PhonebookListView(CampViewMixin, ListView):
     """
     Our phonebook view currently only shows DectRegistration entries,

--- a/src/phonebook/views.py
+++ b/src/phonebook/views.py
@@ -1,4 +1,3 @@
-import csv
 import logging
 import secrets
 import string


### PR DESCRIPTION
Added new DectExportJsonView fixing #1380

*200 reponse*
```json
{"phonebook": [{"number": "1234", "letters": "", "description": "", "activation_code": "7796672559"}, {"number": "8378", "letters": "test", "description": "", "activation_code": "4068685996"}]}
```

*403 reponse*
```json
{"error": 403, "message": "Permission denied"}
```