### PR TITLE
game_team: update description of token page

### DIFF
--- a/src/tokens/templates/tokenfind_list.html
+++ b/src/tokens/templates/tokenfind_list.html
@@ -18,7 +18,7 @@
         <code>[0-9a-zA-Z\.@]{12,32}</code><br><br>
         Tokens are hidden or in plain sight physically or virtually on the BornHack venue, online and offline.</p>
       <p class="lead">If you think you found a secret token you can register it by visiting <code>https://bornhack.dk/token/TOKEN/</code> where <code>TOKEN</code> is replaced by the token you found.</p>
-      <p class="lead">This page shows an overview of the tokens in this years game, a hint for each token, and how many of them you have found. Here is your first token to start the hunt: "ThankYouForParticipaing"</p>
+      <p class="lead">This page shows an overview of the tokens in this years game, a hint for each token, and how many of them you have found. Here is your first token to start the hunt: "HelloTokenHunters2023"</p>
 
       <table class="table">
         <tbody>

--- a/src/tokens/templates/tokenfind_list.html
+++ b/src/tokens/templates/tokenfind_list.html
@@ -17,7 +17,7 @@
       <p class="lead">The Secret Token game lasts the whole event and is about finding little text strings matching the regular expression:<br><br>
         <code>[0-9a-zA-Z\.@]{12,32}</code><br><br>
         Tokens are hidden or in plain sight physically or virtually on the BornHack venue, online and offline.</p>
-      <p class="lead">If you think you found a secret token you can register it by visiting <code>https://bornhack.dk/token/TOKEN/</code> where <code>TOKEN</code> is replaced by the token you found.</p>
+      <p class="lead">If you think you found a secret token you can register it by visiting <code>https://bornhack.dk/token/TOKEN</code> where <code>TOKEN</code> is replaced by the token you found.</p>
       <p class="lead">This page shows an overview of the tokens in this years game, a hint for each token, and how many of them you have found. Here is your first token to start the hunt: "HelloTokenHunters2023"</p>
 
       <table class="table">


### PR DESCRIPTION
The token on the token introduction page was expired, and has now been updated

Minor mistake: The token URL ending with `https://bornhack.dk/token/<TOKEN>/` or `https://bornhack.dk/token/<TOKEN>` are both valid but it is more readable to not add it `/` at the end.