### PR TITLE
Move external ports to env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ environment_settings.py
 elm-stuff/
 .coverage
 media
+docker/.env

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ build_docker_image:
 	${DOCKER_COMPOSE} build app
 
 copy_env_file:
-	cp src/bornhack/environment_settings.py.dist.dev src/bornhack/environment_settings.py
+	test -f src/bornhack/environment_settings.py || cp src/bornhack/environment_settings.py.dist.dev src/bornhack/environment_settings.py
+	test -f docker/.env || cp docker/.env.dev docker/.env
 
 update_submodules:
 	git submodule update --init --recursive

--- a/docker/.env.dev
+++ b/docker/.env.dev
@@ -1,0 +1,2 @@
+db_port=5432
+web_port=8000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
           context: ../
           dockerfile: docker/Dockerfile
         ports:
-          - "8000:8000"
+          - "${web_port}:8000"
         tty: true
         stdin_open: true
         command: python src/manage.py runserver 0.0.0.0:8000
@@ -43,4 +43,4 @@ services:
           - POSTGRES_USER=postgres
           - POSTGRES_PASSWORD=postgres
         ports:
-          - 5432:5432
+          - ${db_port}:5432


### PR DESCRIPTION
When running both bornhack-website and bma in the same docker compose setup, the external host ports for postgres would conflict. This MR moves the definitions to an environment file, which is created on init, if it does not already exist.