### PR TITLE
Show soldout when negative stock

### DIFF
--- a/src/shop/templates/shop_index.html
+++ b/src/shop/templates/shop_index.html
@@ -62,7 +62,7 @@
 
 
                 {% if product.stock_amount %}
-                  {% if product.left_in_stock == 0 or not product.is_time_available %}
+                  {% if product.left_in_stock <= 0 or not product.is_time_available %}
                     <div class="label label-danger" style="margin-left: 1em;"><!-- We can replace the style when we upgrade to Bootstrap 5. -->
                       Sold out!
                     </div>


### PR DESCRIPTION
Changed to follow same overall logic from product detail, though slightly different setup

This is to allow products to be visible (in an attempts to minimize questions), but indicate that they are unavailable. It's very relevant for merch when getting to the point where stock is running out or we can't get stuff.