### PR TITLE
Added last token found column for 'token_stats'

### DIFF
--- a/src/backoffice/templates/token_stats.html
+++ b/src/backoffice/templates/token_stats.html
@@ -17,6 +17,7 @@
             <tr>
               <th>Email</th>
               <th>Finds</th>
+              <th>Last token found</th>
             </tr>
           </thead>
           <tbody>
@@ -24,6 +25,7 @@
               <tr>
                 <td>{{ user.email }}</td>
                 <td>{{ user.token_find_count }}</td>
+                <td>{{ user.last_token_find }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/src/backoffice/views/game.py
+++ b/src/backoffice/views/game.py
@@ -3,6 +3,8 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.db.models import Count
+from django.db.models import Subquery
+from django.db.models import OuterRef
 from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -99,6 +101,10 @@ class TokenStatsView(CampViewMixin, RaisePermissionRequiredMixin, ListView):
             .distinct("user")
             .values_list("user", flat=True)
         )
+        last_token_find_subquery = TokenFind.objects.filter(
+            user=OuterRef('pk'),
+            token__camp=self.camp
+        ).order_by('-created').values('created')[:1]
         return (
             User.objects.filter(id__in=tokenusers)
             .annotate(
@@ -106,6 +112,7 @@ class TokenStatsView(CampViewMixin, RaisePermissionRequiredMixin, ListView):
                     "token_finds",
                     filter=Q(token_finds__token__camp=self.camp),
                 ),
+                last_token_find=Subquery(last_token_find_subquery)
             )
             .exclude(token_find_count=0)
         )

--- a/src/backoffice/views/game.py
+++ b/src/backoffice/views/game.py
@@ -3,9 +3,9 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.db.models import Count
-from django.db.models import Subquery
 from django.db.models import OuterRef
 from django.db.models import Q
+from django.db.models import Subquery
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import DetailView
@@ -101,10 +101,14 @@ class TokenStatsView(CampViewMixin, RaisePermissionRequiredMixin, ListView):
             .distinct("user")
             .values_list("user", flat=True)
         )
-        last_token_find_subquery = TokenFind.objects.filter(
-            user=OuterRef('pk'),
-            token__camp=self.camp
-        ).order_by('-created').values('created')[:1]
+        last_token_find_subquery = (
+            TokenFind.objects.filter(
+                user=OuterRef("pk"),
+                token__camp=self.camp,
+            )
+            .order_by("-created")
+            .values("created")[:1]
+        )
         return (
             User.objects.filter(id__in=tokenusers)
             .annotate(
@@ -112,7 +116,7 @@ class TokenStatsView(CampViewMixin, RaisePermissionRequiredMixin, ListView):
                     "token_finds",
                     filter=Q(token_finds__token__camp=self.camp),
                 ),
-                last_token_find=Subquery(last_token_find_subquery)
+                last_token_find=Subquery(last_token_find_subquery),
             )
             .exclude(token_find_count=0)
         )


### PR DESCRIPTION
Request from gameteam:
When token hunt ends in a tie, game team needs the ability to see when the users last token was registered.

I've added a subquery to the queryset and a new column in the template.

![localhost_8000_bornhack-2024_backoffice_tokens_stats_](https://github.com/user-attachments/assets/a3d2668d-5146-4ac8-8e50-886659c35b8d)
