### PR TITLE
Change `tz` argument for `datetime.datetime.replace()`

### DIFF
--- a/src/program/utils.py
+++ b/src/program/utils.py
@@ -171,14 +171,14 @@ def save_speaker_availability(form, obj) -> None:
                 int(elements[3]),
                 int(elements[4]),
                 int(elements[5]),
-            ).replace(tz=tz),
+            ).replace(tzinfo=tz),
             datetime.datetime(
                 int(elements[7]),
                 int(elements[8]),
                 int(elements[9]),
                 int(elements[10]),
                 int(elements[11]),
-            ).replace(tz=tz),
+            ).replace(tzinfo=tz),
         )
         available = form.cleaned_data[field]
 


### PR DESCRIPTION
**Exception caused by the bug**
```bash
Traceback (most recent call last):
  File "/home/csh/dev/bornhack/bornhack-website/./src/manage.py", line 14, in <module>
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/.venv/lib/python3.14/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/home/csh/dev/bornhack/bornhack-website/.venv/lib/python3.14/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/.venv/lib/python3.14/site-packages/django/core/management/base.py", line 416, in run_from_argv
    self.execute(*args, **cmd_options)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/.venv/lib/python3.14/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
  File "/home/csh/dev/bornhack/bornhack-website/src/utils/management/commands/bootstrap_devsite.py", line 41, in handle
    bootstrap.bootstrap_full(options)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/src/utils/bootstrap/base.py", line 2312, in bootstrap_full
    self.bootstrap_base(options)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/src/utils/bootstrap/base.py", line 2550, in bootstrap_base
    self.bootstrap_camp(options)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/src/utils/bootstrap/base.py", line 2436, in bootstrap_camp
    self.generate_speaker_availability(camp)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/src/utils/bootstrap/base.py", line 1214, in generate_speaker_availability
    save_speaker_availability(form, sp)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/csh/dev/bornhack/bornhack-website/src/program/utils.py", line 174, in save_speaker_availability
    ).replace(tz=tz),
      ~~~~~~~^^^^^^^
TypeError: replace() got an unexpected keyword argument 'tz'
```